### PR TITLE
Make sure only new update hooks are considered new

### DIFF
--- a/QualityAssuranceTask.php
+++ b/QualityAssuranceTask.php
@@ -207,10 +207,10 @@ class QualityAssuranceTask extends \Task {
       $diff = $git->diff('master', $head, $filepath);
 
       // Find new hook update functions in diff.
-      $regex = '~' . $filename . '_update_7\d{3}~';
+      $regex = '~(\+)(function ' . $filename . '_update_7\d{3})~';
       $contents = is_file($filepath) ? file_get_contents($filepath) : '';
       preg_match_all($regex, $diff, $matches);
-      $updates = $matches[0];
+      $updates = $matches[2];
       $count = count($updates);
     }
 


### PR DESCRIPTION
In certain cases when old update hooks are changed (changes introduced by new coding standards rules for example) they might end up as false positives in the check in case the change is close enough to the function name to show up in the diff.

I made the check more strict to look for the + sign to guarantee that only newly added update hooks are considered.