### PR TITLE
MULTISITE-18278: Extends the Whitespace.ControlStructureSpacing sniff to functions, classes and interfaces.

### DIFF
--- a/phpcs/Standards/QualityAssurance/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/phpcs/Standards/QualityAssurance/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Ensures no whitespace after a control structure.
+ */
+
+/**
+ * Ensures no whitespace after a control structure.
+ *
+ * @category PHP
+ * @package  PHP_CodeSniffer
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class QualityAssurance_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends Squiz_Sniffs_WhiteSpace_ControlStructureSpacingSniff implements PHP_CodeSniffer_Sniff
+{
+
+  /**
+   * Returns an array of tokens this test wants to listen for.
+   *
+   * @return array
+   */
+  public function register()
+  {
+    return array_merge(
+      parent::register(),
+      array(T_FUNCTION, T_CLASS, T_INTERFACE)
+    );
+  }//end register()
+
+}//end class
+
+?>
+

--- a/phpcs/Standards/QualityAssurance/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/phpcs/Standards/QualityAssurance/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -20,10 +20,7 @@ class QualityAssurance_Sniffs_WhiteSpace_ControlStructureSpacingSniff extends Sq
    */
   public function register()
   {
-    return array_merge(
-      parent::register(),
-      array(T_FUNCTION, T_CLASS, T_INTERFACE)
-    );
+    return array(T_FUNCTION, T_CLASS, T_INTERFACE);
   }//end register()
 
 }//end class

--- a/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/ControlStructureSpacingSniffTest.php
+++ b/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/ControlStructureSpacingSniffTest.php
@@ -1,0 +1,54 @@
+<?php
+
+class QualityAssurance_Sniffs_WhiteSpace_ControlStructureSpacingUnitTest extends CoderSniffUnitTest
+{
+
+  /**
+   * Returns the lines where errors should occur.
+   *
+   * The key of the array should represent the line number and the value
+   * should represent the number of errors that should occur on that line.
+   *
+   * @return array(int => int)
+   */
+  public function getErrorList($testFile)
+  {
+    // All the error-free  files have no errors.
+    return [11 => 1, 22 => 1, 25 => 1, 32 => 1];
+
+  }//end getErrorList()
+
+
+  /**
+   * Returns the lines where warnings should occur.
+   *
+   * The key of the array should represent the line number and the value
+   * should represent the number of warnings that should occur on that line.
+   *
+   * @return array(int => int)
+   */
+  public function getWarningList($testFile)
+  {
+    // All the warning-free  files have no warnings.
+    return [];
+
+  }//end getWarningList()
+
+
+  /**
+   * Returns a list of test files that should be checked.
+   *
+   * The key of the array should represent the file that should be tested.
+   * The value of the array represents the fixed file to compare against.
+   *
+   * @return array('fileToTest" => 'fixedFile')
+   */
+  public function getTestFiles() {
+    return array(
+      'error/ControlStructureSpacingSniff.module' => '',
+    );
+  }// end getTestFiles()
+
+
+}//end class
+

--- a/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/error/ControlStructureSpacingSniff.module
+++ b/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/error/ControlStructureSpacingSniff.module
@@ -33,3 +33,29 @@ interface YouTouchMy {
 
   public function Tralala();
 }
+
+function plop($super, $cali, $fragilistic, $expialidocious) {
+  if ($super == $cali) {
+    return 'Marry';
+  }
+  if ($fragilistic == $expialidocious) {
+    return 'Poppins';
+  }
+}
+
+function roll() {
+  for($i = 0; $i < 100; $i++) {
+    echo 'Never gonna give you up, never gonna give you up';
+  }
+  for($i = 0; $i < 100; $i++) {
+    echo 'Never gonna tell a lie and hurt you';
+  }
+}
+
+function guessWhosBack($c, $o, $r, $e, $t, $e, $a, $m) {
+  if ($c == $o) {
+    return $c.$o.$r.$e;
+  } else {
+    return $t.$e.$a.$m;
+  }
+}

--- a/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/error/ControlStructureSpacingSniff.module
+++ b/phpcs/Standards/QualityAssurance/Tests/WhiteSpace/error/ControlStructureSpacingSniff.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * This file contains code to testing purpose only.
+ */
+
+/**
+ * Implments hook_install()
+ */
+function Update7000Error_install() {
+
+  FunctionsDeclarationsError_update_7001();
+}
+
+
+/**
+ * Implements hook_enable().
+ */
+function Update7000Error_enable() {
+  drupal_set_message(t("The feature jrccties_core has been enabled."), 'status');
+
+}
+
+class GettingJiggyWithIt {
+
+  public function NaNaNaNaNaNa() {
+    return 'hook';
+  }
+}
+
+interface YouTouchMy {
+
+  public function Tralala();
+}


### PR DESCRIPTION
Extend the default sniff to avoid confusion about those empty lines after or before the end of a control structure.