### PR TITLE
DQA-1418: Do not force use of discouraged method `FileSystemInterface::realpath()`

### DIFF
--- a/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
+++ b/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
@@ -41,7 +41,6 @@ class DrupalWrappersSniff extends ForbiddenFunctionsSniff
         'dirname'                    => 'FileSystemInterface::dirname',
         'mkdir'                      => 'FileSystemInterface::mkdir',
         'move_uploaded_file'         => 'FileSystemInterface::mkdir',
-        'realpath'                   => 'FileSystemInterface::realpath',
         'rmdir'                      => 'FileSystemInterface::rmdir',
         'tempnam'                    => 'FileSystemInterface::tempnam',
         'unlink'                     => 'FileSystemInterface::unlink',


### PR DESCRIPTION
The method `FileSystemInterface::realpath()` is discouraged from being used in a general way and is only applicable under specific circumstances. We should not force projects to use this. Ref. https://api.drupal.org/api/drupal/core!lib!Drupal!Core!File!FileSystemInterface.php/function/FileSystemInterface%3A%3Arealpath

In the proposed use case of the sniff (which is to replace calls to the native PHP `realpath()`) it makes no sense to use `FileSystemInterface::realpath()`. The PHP `realpath()` only accepts filesystem paths and no streams. If we update our code as suggested and pass a path to `FileSystemInterface::realpath()`, the implementation ends up doing some checks and then falls back to the PHP `realpath()`

So the end result of implementing the change suggested by the sniff only results in making existing code slower.

Ref. https://citnet.tech.ec.europa.eu/CITnet/jira/browse/DQA-1418