### PR TITLE
DQA-4074: Update package phpunit/phpunit.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "openeuropa/task-runner": "^1.0.0-beta6",
-        "phpunit/phpunit": ">=3.7 <6"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpro/grumphp": "^1.5",
         "drupal/coder": "^8.3",
         "cweagans/composer-patches": "^1.7",
-        "composer/xdebug-handler": "^1.4",
+        "composer/xdebug-handler": "^3.0",
         "phpmd/phpmd": "^2.10"
     },
     "require-dev": {


### PR DESCRIPTION
Remaining packages:

```
> composer outdated -D
Color legend:
- patch or minor release available - update recommended
- major release available - update possible
phpro/grumphp v1.5.1 v1.12.0 A composer plugin that enables source code quality checks.
```
The package grumphp > 1.5.1 requires the PHP 8.0.
```
- phpro/grumphp[v1.7.0, ..., v1.10.0] require php ^8.0 -> your php version (7.4.29) does not satisfy that requirement.
```