### PR TITLE
DQA-13251: Remove check of deprecated basename call

### DIFF
--- a/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
+++ b/phpcs/QualityAssurance/Sniffs/Functions/DrupalWrappersSniff.php
@@ -35,7 +35,6 @@ class DrupalWrappersSniff extends ForbiddenFunctionsSniff
         'register_shutdown_function' => 'drupal_register_shutdown_function',
         'set_time_limit'             => 'drupal_set_time_limit',
         'xml_parser_create'          => 'drupal_xml_parser_create',
-        'basename'                   => 'FileSystemInterface::basename',
         'chmod'                      => 'FileSystemInterface::chmod',
         'dirname'                    => 'FileSystemInterface::dirname',
         'mkdir'                      => 'FileSystemInterface::mkdir',


### PR DESCRIPTION
Since Drupal 11.3 the usage of `FileSystemInterface::basename()` is deprecated, therefore the check to use it instead of the native `basename()` should be removed.

Reference: https://www.drupal.org/node/3530869